### PR TITLE
meas: Extend orientation units

### DIFF
--- a/include/step/measurement/ext_orientation.h
+++ b/include/step/measurement/ext_orientation.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef STEP_MEASUREMENT_EXT_ORIENT_H__
+#define STEP_MEASUREMENT_EXT_ORIENT_H__
+
+#include <step/step.h>
+
+/**
+ * @brief STEP_MES_TYPE_ORIENTATION extended type definitions
+ * @ingroup MEASUREMENT
+ * @{
+ */
+
+/**
+ * @file
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Extended measurement types for STEP_MES_TYPE_ORIENTATION (8-bit). */
+enum step_mes_ext_orientation {
+	STEP_MES_EXT_TYPE_ORIENTATION_UNDEFINED        = 0, /**< Radian */
+	STEP_MES_EXT_TYPE_ORIENTATION_ANG_MEASURE      = 1, /**< Radian or Degree */
+	STEP_MES_EXT_TYPE_ORIENTATION_UNIT_QUATERNION  = 2,	/**< AKA versor */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* STEP_MEASUREMENT_EXT_ORIENT_H__ */

--- a/include/step/measurement/unit.h
+++ b/include/step/measurement/unit.h
@@ -174,8 +174,12 @@ enum step_mes_unit_si {
 	/* 0x0080..0x008F (128-143): 'Unitless' Units. */
 	/** @brief %, 0.0 .. 100.0 inclusive. */
 	STEP_MES_UNIT_SI_PERCENT                = 0x80,
-	/** @brief 0.0 .. 1.0 inclusive. */
+	/** @brief +/- 0.0 .. 1.0 inclusive. */
 	STEP_MES_UNIT_SI_INTERVAL               = 0x81,
+	/** @brief +/- 0.0 ... 359.99 inclusive. Not an offical IS unit for
+	 *  angular measurements (which should be STEP_MES_UNIT_SI_RADIAN), but
+	 *  it is listed as an 'accepted' unit. */
+	STEP_MES_UNIT_SI_DEGREE                 = 0x82,
 
 	/* 0x1000..0x10FF: STEP_MES_TYPE_AREA Combined Units. */
 	/** @brief m^2 */


### PR DESCRIPTION
Extends the orientation measurement type with new extended
values for angular measurement and unit quaternions (versors).
Also adds a 'degree' SI unit, which isn't an official unit but is
listed as an 'accepted' value.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>