### PR TITLE
proc_mgr: introducing event driven thread option

### DIFF
--- a/Kconfig.step
+++ b/Kconfig.step
@@ -67,9 +67,20 @@ config STEP_PROC_MGR_NODE_LIMIT
 	  memory wihout instrumentation, or STEP_PROC_MGR_NODE_LIMIT * 24 if
 	  CONFIG_STEP_INSTRUMENTATION is enabled.
 
+config STEP_PROC_MGR_EVENT_DRIVEN
+	bool "Enables the process manager to be event driven"
+	default n
+	help
+	This option makes the processor manager background thread
+		execute in an event driven fashion.  A single measurement in
+		the FIFO in a pending state will cause the thread to trigger.
+		When enabled, the pipeline execution rate will be determined
+		by the sensor data througput.
+
 config STEP_PROC_MGR_POLL_RATE
 	int "Rate in Hz to poll the measurement pool."
-	default 10
+	default 0 if STEP_PROC_MGR_EVENT_DRIVEN
+	default 10 
 	range 0 100
 	help
 	  Determines the rate, in Hz, that the processor node manager should poll
@@ -79,6 +90,7 @@ config STEP_PROC_MGR_POLL_RATE
 
 config STEP_PROC_MGR_PRIORITY
 	int "Priority level for the polling thread."
+	default 0 if STEP_PROC_MGR_EVENT_DRIVEN
 	default 7
 	help
 	  Sets the priority level for the polling thread that is created when

--- a/include/step/sample_pool.h
+++ b/include/step/sample_pool.h
@@ -54,6 +54,14 @@ void step_sp_put(struct step_measurement *mes);
 struct step_measurement *step_sp_get(void);
 
 /**
+ * @brief Gets an step_measurement from the pool's FIFO, blocks until a sample
+ *        is available.
+ *
+ * @return A pointer to the measurement.
+ */
+struct step_measurement *step_sp_get_until_available(void);
+
+/**
  * @brief Frees the heap memory associated with 'ds'.
  *
  * @param mes Pointer to the step_measurement whose memory should be freed.

--- a/src/sample_pool.c
+++ b/src/sample_pool.c
@@ -26,6 +26,7 @@ struct step_sp_stats {
 	uint32_t bytes_freed_total;
 	uint32_t fifo_put_calls;
 	uint32_t fifo_get_calls;
+	uint32_t fifo_get_av_calls;
 	uint32_t pool_free_calls;
 	uint32_t pool_flush_calls;
 	uint32_t pool_alloc_calls;
@@ -44,6 +45,12 @@ struct step_measurement *step_sp_get(void)
 {
 	step_sp_stats_inst.fifo_get_calls++;
 	return k_fifo_get(&step_fifo, K_NO_WAIT);
+}
+
+struct step_measurement *step_sp_get_until_available(void)
+{
+	step_sp_stats_inst.fifo_get_available_calls++;
+	return k_fifo_get(&step_fifo, K_FOREVER);
 }
 
 void step_sp_free(struct step_measurement *mes)
@@ -143,6 +150,7 @@ void step_sp_print_stats(void)
 	printk("bytes_freed_total: %d\n", step_sp_stats_inst.bytes_freed_total);
 	printk("fifo_put_calls:    %d\n", step_sp_stats_inst.fifo_put_calls);
 	printk("fifo_get_calls:    %d\n", step_sp_stats_inst.fifo_get_calls);
+	printk("fifo_get_av_calls: %d\n", step_sp_stats_inst.fifo_get_av_calls);
 	printk("pool_free_calls:   %d\n", step_sp_stats_inst.pool_free_calls);
 	printk("pool_flush_calls:  %d\n", step_sp_stats_inst.pool_flush_calls);
 	printk("pool_alloc_calls:  %d\n", step_sp_stats_inst.pool_alloc_calls);


### PR DESCRIPTION
for step process manager, which is triggered by FIFO samples incoming. 
This allows to keep the node execution automatic without polling
manually the process manager.

To enable just hit the option CONFIG_STEP_PROC_MGR_EVENT_DRIVEN in the menuconfig.

One limitation, periodic polling cannot be used if event driven process manager is enabled, and it is automatically disabled if the event thread mechanism is used.

I also kept the compatibillity of the manually polling to avoid unit tests breaking.