### PR TITLE
WIP: samples: fusion_imu: added integral limit

### DIFF
--- a/samples/fusion_imu/src/zsl_fusion_config.c
+++ b/samples/fusion_imu/src/zsl_fusion_config.c
@@ -9,7 +9,8 @@
 static zsl_real_t _mahn_intfb[3] = { 0.0, 0.0, 0.0 };
 struct zsl_fus_mahn_cfg mahn_cfg = {
 	.kp = 200,
-	.ki = 0.00200,
+	.ki = 0.02200,
+	.integral_limit = 1000.0f,
 	.intfb = {
 		.sz = 3,
 		.data = _mahn_intfb,


### PR DESCRIPTION
To the mahony filter for wind-up avoidance.

Before merging, this PR is also required to reach upstream: https://github.com/zephyrproject-rtos/zscilib/pull/35

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>