### PR TITLE
samples: fusion_imu: add fovever and timed

### DIFF
--- a/samples/fusion_imu/README.rst
+++ b/samples/fusion_imu/README.rst
@@ -80,14 +80,14 @@ command sets to start the data streaming over the console, there are two options
 of streaming data:
 
 .. code-block:: console
-    $ step_fusion stream forever
+    $ step_fusion stream 0
 
 The command above will start the streaming data which stays running until the board
 gets reset. Alternatively user may use the following command to make the board streaming
 data for a fixed amount of time in seconds:
 
 .. code-block:: console
-    $ step_fusion stream timed 10
+    $ step_fusion stream 10
 
 The command above will make the board stream the fused data for 10 seconds, stopping at 
 the end and available for new commands. Use this option during tunning before use the 

--- a/samples/fusion_imu/README.rst
+++ b/samples/fusion_imu/README.rst
@@ -76,8 +76,22 @@ its source code:
 * The source code: https://github.com/nathandunk/BetterSerialPlotter
 
 After tunning the fusion algorithm, just type the command stream from step_fusion
-command sets to start the data streaming over the console, this command takes an extra
-argument which is the streaming data in seconds.
+command sets to start the data streaming over the console, there are two options 
+of streaming data:
+
+.. code-block:: console
+    $ step_fusion stream forever
+
+The command above will start the streaming data which stays running until the board
+gets reset. Alternatively user may use the following command to make the board streaming
+data for a fixed amount of time in seconds:
+
+.. code-block:: console
+    $ step_fusion stream timed 10
+
+The command above will make the board stream the fused data for 10 seconds, stopping at 
+the end and available for new commands. Use this option during tunning before use the 
+contionous streaming way above.
 
 Mahoney Tunning
 ***************

--- a/samples/fusion_imu/src/main.c
+++ b/samples/fusion_imu/src/main.c
@@ -95,17 +95,32 @@ static int step_fusion_cmd_set(const struct shell *shell, size_t argc, char **ar
 
 static int step_fusion_cmd_stream(const struct shell *shell, size_t argc, char **argv)
 {
-	if (argc != 2) {
-		return -EINVAL;
-	}
-	
-	int time = strtol(argv[1], NULL, 10) * 1000;
-	if(time <= 0) {
+	int stream_time = 0; 
+
+	if (argc < 2) {
 		return -EINVAL;
 	}
 
-	k_timer_start(&stream_timer, K_MSEC(time), K_MSEC(0));
-	enable_stream = true;
+	if(!strcmp("forever", argv[1])) 
+	{
+		enable_stream = true;
+
+	} else if (!strcmp("timed", argv[1]) ){
+		if(argc != 3) {
+			return -EINVAL;
+		}
+
+		stream_time = strtol(argv[2], NULL, 10) * 1000;
+		if(stream_time <= 0) {
+			return -EINVAL;
+		}
+
+		enable_stream = true;
+		k_timer_start(&stream_timer, K_MSEC(stream_time), K_MSEC(0));
+
+	} else {
+		return -EINVAL;
+	}
 
 	return 0;
 }
@@ -143,7 +158,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(imu, NULL, "Prints raw sensor data", step_fusion_cmd_imu),
 	SHELL_CMD(calibrate, NULL, "Calibrates the IMU sensor", step_fusion_cmd_calibrate),
 	SHELL_CMD(set_mahoney, NULL, "Sets Mahoney filter kp and ki", step_fusion_cmd_set),
-	SHELL_CMD(stream, NULL, "start orientation data playback over serial for N seconds", step_fusion_cmd_stream),
+	SHELL_CMD(stream, NULL, "start orientation data playback over serial use forever option to continous streaming or timed plus time seconds to timed streaming which stops automatically", step_fusion_cmd_stream),
 	SHELL_SUBCMD_SET_END
 	);
 

--- a/samples/fusion_imu/src/main.c
+++ b/samples/fusion_imu/src/main.c
@@ -97,29 +97,27 @@ static int step_fusion_cmd_stream(const struct shell *shell, size_t argc, char *
 {
 	int stream_time = 0; 
 
-	if (argc < 2) {
+	if ((argc == 1) || (strcmp(argv[1], "help") == 0) || argc > 2) {
+		shell_print(shell, "Starts streaming orientation data.\n");
+		shell_print(shell, "  $ %s %s <timeout_s>\n", argv[-1], argv[0]);
+		shell_print(shell, "  <timeout_s> Time to stream in seconds. 0 = non-stop.\n");
+		shell_print(shell, "Example: %s %s 10", argv[-1], argv[0]);
+		return 0;
+	}
+
+	// Get timeout
+	stream_time = strtol(argv[1], NULL, 10) * 1000;
+	if(stream_time < 0) {
+		shell_print(shell, "Invalid timeout_s: %d", stream_time / 1000);
 		return -EINVAL;
 	}
 
-	if(!strcmp("forever", argv[1])) 
-	{
-		enable_stream = true;
-
-	} else if (!strcmp("timed", argv[1]) ){
-		if(argc != 3) {
-			return -EINVAL;
-		}
-
-		stream_time = strtol(argv[2], NULL, 10) * 1000;
-		if(stream_time <= 0) {
-			return -EINVAL;
-		}
-
-		enable_stream = true;
+	// Enable stream
+	enable_stream = true;
+	
+	// Start the timer if time isn't infinite (0)
+	if (stream_time) {
 		k_timer_start(&stream_timer, K_MSEC(stream_time), K_MSEC(0));
-
-	} else {
-		return -EINVAL;
 	}
 
 	return 0;
@@ -158,7 +156,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(imu, NULL, "Prints raw sensor data", step_fusion_cmd_imu),
 	SHELL_CMD(calibrate, NULL, "Calibrates the IMU sensor", step_fusion_cmd_calibrate),
 	SHELL_CMD(set_mahoney, NULL, "Sets Mahoney filter kp and ki", step_fusion_cmd_set),
-	SHELL_CMD(stream, NULL, "start orientation data playback over serial use forever option to continous streaming or timed plus time seconds to timed streaming which stops automatically", step_fusion_cmd_stream),
+	SHELL_CMD(stream, NULL, "Streams orientation data", step_fusion_cmd_stream),
 	SHELL_SUBCMD_SET_END
 	);
 


### PR DESCRIPTION
options to the stream command, allowing
timed and continuous fused data streaming.

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>