### PR TITLE
samples: foc_controller: replace sine modulation

### DIFF
--- a/samples/foc_controller/CMakeLists.txt
+++ b/samples/foc_controller/CMakeLists.txt
@@ -3,5 +3,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(step_foc)
 
 target_sources(app PRIVATE src/foc_driver.c)
+target_sources(app PRIVATE src/foc_svm.c)
 target_sources(app PRIVATE src/main.c)
 target_sources(app PRIVATE src/foc_nodes.c)

--- a/samples/foc_controller/src/foc_driver.h
+++ b/samples/foc_controller/src/foc_driver.h
@@ -54,14 +54,12 @@ struct foc_controller_payload {
  * 
  * @param cb user callback to be executed each measurement from motor rotor position.
  * 
- * @param dc_link_voltage inverter dc bus voltage in volts.
- *
  * @param motor_pole_pairs number of motor pole pairs.
  * 
  * @return int  0 on success, otherwise a negative error code.
  * 
  */
-int foc_driver_initialize(float motor_pole_pairs, float dc_link_voltage, foc_measurement_callback_t cb);
+int foc_driver_initialize(float motor_pole_pairs, foc_measurement_callback_t cb);
 
 
 /**
@@ -73,14 +71,17 @@ int foc_driver_initialize(float motor_pole_pairs, float dc_link_voltage, foc_mea
 int foc_driver_set_encoder_offset(void);
 
 /**
- * @brief set inverter voltages.
+ * @brief set inverter voltages based on duty cycle.
  * 
- * @param voltage_u voltage to be applied to the in phase u of motor
+ * @param dc_u voltage to be applied to the in phase u of motor
  *
- * @param voltage_v voltage to be applied to the in phase v of motor
+ * @param dc_v voltage to be applied to the in phase v of motor
+ *
+ * @param dc_v voltage to be applied to the in phase v of motor
  * 
+ * @param values should be normalized between 0 and 1 
  */
-void foc_driver_set_voltages(float voltage_u, float voltage_v);
+void foc_driver_set_duty_cycle(float dc_u, float dc_v, float dc_w);
 
 #ifdef __cplusplus
 }

--- a/samples/foc_controller/src/foc_svm.c
+++ b/samples/foc_controller/src/foc_svm.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 Teslabs Engineering S.L.
+ * Copyright (c) 2022 Linaro 
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/util.h>
+#include <arm_math.h>
+#include "foc_svm.h"
+
+/** Value sqrt(3). */
+#define SQRT_3 1.7320508075688773f
+static const float sqrt3_by_two = SQRT_3 / 2.0f;
+
+/**
+ * @brief Obtain sector based on a, b, c vector values.
+ *
+ * @param[in] a a component value.
+ * @param[in] b b component value.
+ * @param[in] c c component value.
+
+ * @return Sector (1...6).
+ */
+static uint8_t get_sector(float a, float b, float c)
+{
+	uint8_t sector = 0U;
+
+	if (c < 0.0f) {
+		if (a < 0.0f) {
+			sector = 2U;
+		} else {
+			if (b < 0.0f) {
+				sector = 6U;
+			} else {
+				sector = 1U;
+			}
+		}
+	} else {
+		if (a < 0.0f) {
+			if (b <= 0.0f) {
+				sector = 4U;
+			} else {
+				sector = 3U;
+			}
+		} else {
+			sector = 5U;
+		}
+	}
+
+	return sector;
+}
+
+void foc_svm_set(float v_alpha, float v_beta, float *dca, float *dcb, float *dcc)
+{
+	float a, b, c, mod;
+	float x, y, z;
+
+	/* normalize and limit alpha-beta vector */
+	(void)arm_sqrt_f32(v_alpha * v_alpha + v_beta * v_beta, &mod);
+	if (mod > sqrt3_by_two) {
+		v_alpha = v_alpha / mod * sqrt3_by_two;
+		v_beta = v_beta / mod * sqrt3_by_two;
+	}
+
+	/* do a modified inverse clarke transform to get an auxiliary frame 
+	 * to compute the sector we are
+	 */
+	a = v_alpha;
+	b = 0.5f * (-v_alpha - SQRT_3 * v_beta);
+	c = 0.5f * (-v_alpha + SQRT_3 * v_beta); 
+
+	switch (get_sector(a, b, c)) {
+	case 1U:
+		x = a;
+		y = b;
+		z = 1.0f - (x + y);
+
+		*dca = x + y + z * 0.5f;
+		*dcb = y + z * 0.5f;
+		*dcc = z * 0.5f;
+
+		break;
+	case 2U:
+		x = -c;
+		y = -a;
+		z = 1.0f - (x + y);
+
+		*dca = x + z * 0.5f;
+		*dcb = x + y + z * 0.5f;
+		*dcc = z * 0.5f;
+
+		break;
+	case 3U:
+		x = b;
+		y = c;
+		z = 1.0f - (x + y);
+
+		*dca = z * 0.5f;
+		*dcb = x + y + z * 0.5f;
+		*dcc = y + z * 0.5f;
+
+		break;
+	case 4U:
+		x = -a;
+		y = -b;
+		z = 1.0f - (x + y);
+
+		*dca = z * 0.5f;
+		*dcb = x + z * 0.5f;
+		*dcc = x + y + z * 0.5f;
+
+		break;
+	case 5U:
+		x = c;
+		y = a;
+		z = 1.0f - (x + y);
+
+		*dca = y + z * 0.5f;
+		*dcb = z * 0.5f;
+		*dcc = x + y + z * 0.5f;
+
+		break;
+	case 6U:
+		x = -b;
+		y = -c;
+		z = 1.0f - (x + y);
+
+		*dca = x + y + z * 0.5f;
+		*dcb = z * 0.5f;
+		*dcc = x + z * 0.5f;
+
+		break;
+	default:
+		break;
+	}
+}

--- a/samples/foc_controller/src/foc_svm.h
+++ b/samples/foc_controller/src/foc_svm.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 Linaro
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Modulate the alpha-beta frame voltage into Space Vector PWM.
+ *
+ * @param v_alpha voltage alpha component obtained from inverse park step
+ *
+ * @param v_beta voltage beta component obtained from inverse park step
+ * 
+ * @param dc_u pointer to the voltage to be applied to the in phase u of motor
+ *
+ * @param dc_v pointer voltage to be applied to the in phase v of motor
+ *
+ * @param dc_v pointer voltage to be applied to the in phase v of motor
+ *  
+ */
+void foc_svm_set(float v_alpha, float v_beta, float *dca, float *dcb, float *dcc);

--- a/samples/foc_controller/src/main.c
+++ b/samples/foc_controller/src/main.c
@@ -13,7 +13,6 @@
 #include "foc_nodes.h"
 
 #define SAMPLE_MOTOR_POLE_PAIRS 	7
-#define SAMPLE_DC_LINK_VOLTAGE_MV  	12000
 
 static float motor_vq;
 static float motor_vd;
@@ -38,7 +37,6 @@ void main(void)
 
 	/* initialize the foc driver first */
 	rc = foc_driver_initialize(SAMPLE_MOTOR_POLE_PAIRS,
-							(SAMPLE_DC_LINK_VOLTAGE_MV / 1000.0f),
 							on_foc_measurement);
 	if (rc) {
 		printk("foc driver init failed!\n");
@@ -72,8 +70,8 @@ static int step_foc_cmd_align(const struct shell *shell, size_t argc, char **arg
 /* Subcommand array for "step_foc" (level 1). */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_step_foc,
-	SHELL_CMD(set, NULL, "Set voltages to control the motor", step_foc_cmd_set),
-	SHELL_CMD(align, NULL, "Align rotor and calibrate sensor", step_foc_cmd_align),	
+	SHELL_CMD(set, NULL, "Set voltage d-q vector to control the motor between -1 and +1", step_foc_cmd_set),
+	SHELL_CMD(align, NULL, "Align rotor and calibrate its position sensor", step_foc_cmd_align),	
 	SHELL_SUBCMD_SET_END
 	);
 

--- a/src/proc_mgr.c
+++ b/src/proc_mgr.c
@@ -95,11 +95,13 @@ static uint32_t step_pm_handle_counter = 0;
  * they should be evaluated. The 'process' function traverses this list. */
 static sys_slist_t pm_node_slist = SYS_SLIST_STATIC_INIT(&pm_node_slist);
 
+#if (CONFIG_STEP_PM_POLL_RATE > 0) || defined(STEP_PROC_MGR_EVENT_DRIVEN) 
 static void step_pm_poll_thread(bool free);
 /* Create the polling thread. */
 K_THREAD_DEFINE(step_pm_tid, CONFIG_STEP_PROC_MGR_STACK_SIZE,
 		step_pm_poll_thread, 1, NULL, NULL,
 		CONFIG_STEP_PROC_MGR_PRIORITY, 0, 0);
+#endif
 
 /* Registry should be locked during processing or when modifying it. */
 K_MUTEX_DEFINE(step_pm_reg_access);
@@ -462,6 +464,8 @@ err:
 	return rc;
 }
 
+#if (CONFIG_STEP_PM_POLL_RATE > 0) || defined(STEP_PROC_MGR_EVENT_DRIVEN) 
+
 /**
  * @brief Polling handler if automatic polling is requested.
  *
@@ -479,6 +483,7 @@ static void step_pm_poll_thread(bool free)
 
 	}
 }
+#endif
 
 int step_pm_disable_node(uint32_t handle)
 {


### PR DESCRIPTION
with space vector pwm generation, also fixes the rotor
alignment procedure and a problem with step processor
manager that creates a dead loop thread when poll
rate is zero but event driven thread is not defined.

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>